### PR TITLE
Follow-ups from the FOSS Linux review: hot-plug fix, Zoom docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,15 @@ What follows is deliberately specific about what is and is not done, because
   Starling ships none of them. Chrome and VS Code do show their real icons in
   the launcher and dock, read from the host at runtime; the rest fall back to a
   generic glyph, since only those two ids are wired to that lookup.
-- **One catalogued app runs with a caveat.** Zoom starts but complains
-  `no pactl and pacmd found` — nothing in the package pulls in an audio stack,
-  and no first-party app needs one yet.
+- **One catalogued app runs with a caveat.** Zoom starts but reports
+  `no pactl and pacmd found` and has no audio. That is deliberate rather than a
+  missing dependency: Zoom segfaults during audio init whenever `pactl` is on
+  PATH on a PipeWire box with no native PulseAudio daemon, which is the stock
+  Ubuntu 26.04 arrangement. Absent `pactl` it skips audio and runs; present, it
+  crashes, and a working `PULSE_SERVER` does not save it. **Do not install
+  `pulseaudio-utils` to "fix" this** — it trades a silent Zoom for one that will
+  not start. Other libpulse apps (Chrome, Slack, Teams) do get sound; Zoom is a
+  single-app exception until `pactl` can be masked for it alone.
 - **No CI.** Testing is the framework's unit tests plus manual verification in
   a VM.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -179,6 +179,20 @@ bundle them. Install them through the **App Store** (which uses your system's
 `apt`), or with your distribution's own packaging. See the
 [User Guide](USER_GUIDE.md#installing-more-apps).
 
+### Zoom starts but has no audio
+
+Expected in this release — and the obvious fix makes it worse. Zoom reports
+`no pactl and pacmd found` because `pactl` is deliberately not installed: Zoom
+segfaults during audio init whenever `pactl` is on PATH on a PipeWire system
+with no native PulseAudio daemon, which is the stock Ubuntu 26.04 arrangement.
+
+**Do not `apt install pulseaudio-utils`.** With `pactl` absent, Zoom skips audio
+and runs normally; with it present, Zoom crashes at startup, and setting
+`PULSE_SERVER` does not help.
+
+Sound in other apps is unaffected — Chrome, Slack and Teams reach the host's
+PipeWire/PulseAudio socket normally.
+
 ### Getting a clean log for a bug report
 
 ```bash

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -222,8 +222,11 @@ Starling is an early preview (v0.2). A few limits you will notice:
 - **Scaling is fixed at 2.0.** Fractional scaling produced blurry text and is
   not usable yet.
 - **No display-mode picker.** The session uses the connector's preferred mode.
-- **Zoom runs with a caveat** — it starts but reports `no pactl and pacmd
-  found`, because nothing in the package pulls in an audio stack yet.
+- **Zoom runs without audio.** It starts and reports `no pactl and pacmd
+  found`. That message is expected: `pactl` is deliberately left off the system
+  because Zoom crashes at startup when it is present. **Do not install
+  `pulseaudio-utils` to fix it** — that trades a silent Zoom for one that will
+  not start. Sound in other apps (Chrome, Slack, Teams) is unaffected.
 - Verified on **AMD** and **virtio-gpu** graphics; Intel and NVIDIA are not yet
   tested.
 

--- a/shell/Sources/DesktopShellApp/Shell/DisplayLayout.swift
+++ b/shell/Sources/DesktopShellApp/Shell/DisplayLayout.swift
@@ -109,6 +109,30 @@ final class DisplayLayout {
         }
     }
 
+    /// A window keeps its place across a layout change only when at least this
+    /// much of it is still on the visible desktop. Necessarily above 0.5: a
+    /// window split evenly across two outputs has to come home when one of them
+    /// is unplugged, and that is the case bare intersection got wrong.
+    static let minVisibleFractionToStay = 0.75
+
+    /// The fraction of `rect`'s area that lands on the visible desktop, 0…1.
+    ///
+    /// Outputs never overlap — the layout arranges them side by side from the
+    /// engine's enumeration — so per-output intersections sum without double
+    /// counting. Clamped anyway, so an overlapping arrangement would degrade to
+    /// "fully visible" rather than to a fraction above 1.
+    func visibleFraction(ofRect rect: Rect) -> Double {
+        let area = rect.width * rect.height
+        guard area > 0 else { return 0 }
+        var covered = 0.0
+        for o in outputs {
+            let w = max(0.0, min(o.logicalRight, rect.right) - max(o.logicalLeft, rect.left))
+            let h = max(0.0, min(o.logicalBottom, rect.bottom) - max(o.logicalTop, rect.top))
+            covered += w * h
+        }
+        return min(1.0, covered / area)
+    }
+
     /// Keep the primary output's scale in step with a runtime DPI change
     /// (Settings app). Per-output scale for real multi-monitor comes later.
     func updatePrimaryScale(_ scale: Double) {

--- a/shell/Sources/DesktopShellApp/main.swift
+++ b/shell/Sources/DesktopShellApp/main.swift
@@ -358,18 +358,26 @@ func drmOutputsChanged() {
         // Always re-advertise on hotplug — shrinking back to one output
         // must reach clients too.
         waylandIntegration?.setOutputs(dl.outputs)
-        // Windows stranded on an unplugged output come home to the primary
-        // (macOS behavior), keeping their size.
+        // Windows stranded on an unplugged output come home (macOS behavior),
+        // keeping their size. "Stranded" is a matter of degree, not of bare
+        // intersection: a window that straddled the boundary still overlaps the
+        // surviving output, and testing only for zero intersection left it
+        // exactly where it was, with most of its area off the desktop.
+        //
+        // Home is the output it most belongs to among the survivors, not always
+        // the primary — a straddling window stays on the monitor it was mostly
+        // on. owningOutput falls back to the primary when nothing overlaps,
+        // which is the fully-stranded case.
         if let shell = _shellState {
             for win in shell.windowManager.visibleWindows
-            where dl.outputs(intersectingRect: win.rect).isEmpty {
-                let p = dl.primary
+            where dl.visibleFraction(ofRect: win.rect) < DisplayLayout.minVisibleFractionToStay {
+                let home = dl.owningOutput(ofRect: win.rect)
                 let w = win.rect.width
                 let h = win.rect.height
-                let nx = min(max(win.rect.left, p.logicalLeft),
-                             max(p.logicalLeft, p.logicalRight - w))
-                let ny = min(max(win.rect.top, p.logicalTop),
-                             max(p.logicalTop, p.logicalBottom - h))
+                let nx = min(max(win.rect.left, home.logicalLeft),
+                             max(home.logicalLeft, home.logicalRight - w))
+                let ny = min(max(win.rect.top, home.logicalTop),
+                             max(home.logicalTop, home.logicalBottom - h))
                 win.rect = Rect.fromLTWH(nx, ny, w, h)
             }
         }


### PR DESCRIPTION
Two self-contained follow-ups to the [FOSS Linux hands-on of v0.2.1](https://www.fosslinux.com/159653/install-starling-linux-desktop.htm), one commit each.

### `hotplug: a straddling window comes home too` — #15

The one confirmed code defect in the review. Re-homing tested for *zero* intersection with the surviving outputs, so a window spanning two monitors still overlapped the survivor after an unplug and kept its rect, leaving most of its area off the desktop.

Now re-homes on visible **area** (`DisplayLayout.visibleFraction`, threshold 0.75 — necessarily above the 0.5 an even split leaves behind), and lands on the output the window most belongs to rather than always the primary, so a straddling window stays on the monitor it was mostly on. `owningOutput` already falls back to the primary when nothing overlaps, so the fully-stranded case is unchanged.

**Not covered by a test.** The shell package has no test target, and adding one pulls in Flutter and lands on the swift-testing/C++-interop breakage on 26.04 that `test/run.sh` documents. Verified by compiling and by modelling the arithmetic across the straddle, stranded, and fully-visible cases. A physical unplug on two monitors is still the real confirmation, and has not been done.

### `docs: Zoom's absent pactl is deliberate` — #18

The review read Zoom's `no pactl and pacmd found` as a missing audio stack, which leads a user to install `pulseaudio-utils` — turning a working-but-silent Zoom into one that segfaults during audio init. `pactl` is off the system on purpose, and a working `PULSE_SERVER` does not save it.

That reasoning lived only in a comment in `build/app-run.sh`. It is now in the README limitation, the User Guide, and a new INSTALL troubleshooting entry. The code half of the issue — bwrap-masking `/usr/bin/pactl` for Zoom alone — is untouched, so #18 stays open.

---

`test/run.sh` passes locally. Still open from the review: #14 (screen lock), #16 (per-output scale), #17 (display modes), #19 (Intel/NVIDIA), and the code half of #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzjHtcJBgaxAJfwJLx5DbD
